### PR TITLE
add version desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ A web3 note-taking tool built for open and interactive block reference. Everyone
 Use this Chrome extension to experience portable, block-based note-taking backed by authenticated data. You could do block references in your writing (e.g. on [Mirror.xyz](https://mirror.xyz/conaw.eth/hBj9GSkYzLpQM524VBVhjO8C5-KQFw9UmfrYkerlvZE)), not only can you search and refer your own word blocks but also blocks created by anyone with a wallet. Once publish your writing, your publication is no longer a plain text, but interactive, block-chained knowledge graphs with verifiable ownership. See the demo video [here](https://www.youtube.com/watch?v=lp3NMGuktZc).
 
 ## Get Started
-
-Environments:
+Prerequisites:
 - Node version >= 16
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Use this Chrome extension to experience portable, block-based note-taking backed
 
 ## Get Started
 
+Enviroments:
+- Node version >= 16
+
 ```sh
 $ git clone https://github.com/fat-garage/wordblock
 $ yarn install

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use this Chrome extension to experience portable, block-based note-taking backed
 
 ## Get Started
 
-Enviroments:
+Environments:
 - Node version >= 16
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "key-did-provider-ed25519": "^2.0.1",
     "key-did-resolver": "^2.0.5",
     "lodash": "^4.17.21",
-    "web3.storage": "3.4.0",
     "metamask-extension-provider": "3.0.0",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
@@ -59,6 +58,7 @@
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "styled-system": "^5.1.2",
+    "web3.storage": "3.4.0",
     "webextension-polyfill-ts": "^0.25.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Add node version prepresiquites: node version >= 16. It would fail to install some dependencies otherwise.
Add cross-env dependencies. It would fail to execute "yarn build"on Windows otherwise.